### PR TITLE
build using user images

### DIFF
--- a/build_dockerfile.sh
+++ b/build_dockerfile.sh
@@ -8,5 +8,5 @@ TAG=$(git symbolic-ref --short -q HEAD)
 cd ${IMG_TYPE}
 
 # and put in a repository named after the current user
-docker build -t ${USER}/${IMG_TYPE}:${TAG} -f Dockerfile .
+docker build -t ${USER}/${IMG_TYPE}:${TAG} --build-arg USER=${USER} -f Dockerfile .
 

--- a/build_dockerfile.sh
+++ b/build_dockerfile.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-IMG_TYPE=${1}
+IMG_TYPE=${1%/}
 
 # tag the image with the current git branch name
 TAG=$(git symbolic-ref --short -q HEAD)

--- a/pytorch_datascience/Dockerfile
+++ b/pytorch_datascience/Dockerfile
@@ -1,5 +1,6 @@
 # From pytorch compiled from source
-FROM rorydm/pytorch_extended:master
+ARG USER
+FROM $USER/pytorch:master
 
 # pre-reqs for base notebooks from jupyter-stacks
 ENV export DEBIAN_FRONTEND=noninteractive
@@ -44,7 +45,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # R packages
-RUN conda install -y --name pytorch-py35 -c r \
+RUN conda install -y --name pytorch-py$PYTHON_VERSION -c r \
     r-base \
     r-irkernel \
     r-devtools \

--- a/pytorch_extended/Dockerfile
+++ b/pytorch_extended/Dockerfile
@@ -1,15 +1,16 @@
 # From pytorch compiled from source
-FROM rorydm/pytorch:master
+ARG USER
+FROM $USER/pytorch:master
 
-# pytoch image comes with:
+# pytorch image comes with:
 #   ubuntu: build-essential cmake git curl vim ca-certificates libjpeg-dev libpng-dev
-#   python: numpy pyyaml scipy ipython mkl (in the pytorch-py35 conda environment)
+#   python: numpy pyyaml scipy ipython mkl (in the pytorch-py$PYTHON_VERSION conda environment)
 
 
 ## first we augment python with more libraries
 
 # install more python stuff
-RUN conda install -y --name pytorch-py35 \
+RUN conda install -y --name pytorch-py$PYTHON_VERSION \
     jupyter \
     natsort \
     pillow \
@@ -55,5 +56,5 @@ COPY custom.js /root/.jupyter/custom
 EXPOSE 9999
 
 # move to home dir for root
-WORKDIR "/root"
+WORKDIR "/root" 
 


### PR DESCRIPTION
the build scripts now use the bash $USER variable to build the images into the everyone's individual docker repos to avoid conflicts.

It would be worth thinking about an aics_modelling user account that would build our canonical versions and push them to dockerhub